### PR TITLE
写真からプロト詳細へ遷移

### DIFF
--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,5 +1,5 @@
 <div class="card">
-  <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype.user) %>
+  <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype) %>
   <div class="card__body">
     <%= link_to prototype.title, prototype_path(prototype), class: :card__title%>
     <p class="card__summary">


### PR DESCRIPTION
# what
トップページのビュー(_prototype)ファイルの修正

# why
プロト詳細へ正しく遷移させるため