### PR TITLE
prototypeへid設定

### DIFF
--- a/app/views/prototypes/_prototype.html.erb
+++ b/app/views/prototypes/_prototype.html.erb
@@ -1,7 +1,7 @@
 <div class="card">
-  <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype.user) %>
+  <%= link_to image_tag(prototype.image, class: :card__img ), prototype_path(prototype.id) %>
   <div class="card__body">
-    <%= link_to prototype.title, prototype_path(prototype), class: :card__title%>
+    <%= link_to prototype.title, prototype_path(prototype.id), class: :card__title%>
     <p class="card__summary">
       <%= prototype.catch_copy %>
     </p>


### PR DESCRIPTION
#what
prototype.html.erb内の記述にprototype.idを設定

#why
トップページの写真をクリックしたときにプロト詳細画面へ遷移し、写真が表示させるため